### PR TITLE
Sigma convolution

### DIFF
--- a/pba/pbox.py
+++ b/pba/pbox.py
@@ -2,7 +2,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from .interval import Interval
-from .copula import Copula, pi
+from .copula import Copula, pi, Gaussian
 
 class Pbox(object):
 
@@ -162,9 +162,9 @@ class Pbox(object):
             self.var_right = right(b)
 
     ### Public funtions ###
-    def add(self, other, method = 'f'):
+    def add(self, other, method = 'f', corr = 0):
 
-        if method not in ['f','p','o','i']:
+        if method not in ['f','p','o','i', 'c']:
             raise ArithmeticError("Calculation method unkown")
 
         if other.__class__.__name__ == 'Interval':
@@ -211,6 +211,12 @@ class Pbox(object):
                 for ii in self.right:
                     for jj in other.right:
                         nright.append(ii+jj)
+            
+            elif method == 'c':
+                if corr == 1: return self.add(other,method='p')
+                if corr == -1: return self.add(other,method='o')
+                if corr == 0: return self.add(other,method='i')
+                return self.sigma(other, lambda x,y: x+y, Gaussian(corr))
 
             nleft.sort()
             nright.sort()
@@ -252,9 +258,9 @@ class Pbox(object):
 
         return self.add(-other, method)
 
-    def mul(self, other, method = 'f'):
+    def mul(self, other, method = 'f', corr = 0):
 
-        if method not in ['f','p','o','i']:
+        if method not in ['f','p','o','i', 'c']:
             raise ArithmeticError("Calculation method unkown")
 
         if other.__class__.__name__ == 'Interval':
@@ -301,6 +307,12 @@ class Pbox(object):
                 for ii in self.right:
                     for jj in other.right:
                         nright.append(ii*jj)
+
+            elif method == 'c':
+                if corr == 1: return self.mul(other,method='p')
+                if corr == -1: return self.mul(other,method='o')
+                if corr == 0: return self.mul(other,method='i')
+                return self.sigma(other, lambda x,y: x*y, Gaussian(corr))
 
             nleft.sort()
             nright.sort()

--- a/pba/pbox.py
+++ b/pba/pbox.py
@@ -354,7 +354,7 @@ class Pbox(object):
 
         return self.mul(1/other, method)
 
-    def sigma(self, other, op = lambda x,y: x+y, C = pi()):
+    def sigma(self, other, op = lambda x,y: x*y, C = pi()):
 
         m = self.n
         p = other.n


### PR DESCRIPTION
Adds sigma convolution for performing correlated operations.

- Inputs: 2 pboxes, a (positive) binary operator and a copula
- Computes: the resulting pbox from the binary operator following the copula dependence

Added methods:
- sigma: main convolution function
- correlated option to `+,-,*,/`, as `method = 'c'` (correlated) and corr argument (default 0)

eg:
```python
d = pba.U(0,1)
f = d.sigma(d, lambda x,y: x+y, pba.Gaussian(0.5))   # Binary operator must be given as lambda function 

f = d.add(d, method = 'c', corr = 0.5)  # Does the same above. Default copula is gaussian
```
